### PR TITLE
replace PHP4 style constructor for class plTable

### DIFF
--- a/cms/app/extralib/lib/plTable.php
+++ b/cms/app/extralib/lib/plTable.php
@@ -40,7 +40,7 @@ class plTable
 	var $min_row_height = '';
 	
 	
-	function plTable($table_name='default')
+	function __construct($table_name='default')
 	{
 		$this->table_name = $table_name;
 	}


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP; plTable has a deprecated constructor in /opt/bitnami/apache2/htdocs/ocm/cms/app/extralib/lib/plTable.php on line 25.

The new syntax was introduced in PHP5 but the old style did not become deprecated until PHP7.

The syntax in this patch is a drop-in replacement. It should be compatible with both PHP 5 and PHP 7.

https://www.php.net/manual/en/language.oop5.decon.php
https://www.php.net/manual/en/migration70.deprecated.php
https://stackoverflow.com/a/37100413