### PR TITLE
Handle calls to getNotes passing too few args

### DIFF
--- a/cms/app/lib/pikaCase.php
+++ b/cms/app/lib/pikaCase.php
@@ -266,7 +266,7 @@ class pikaCase extends plBaseWithUdf
 	}
 	
 	
-	public function getNotes($order = 'ASC', $list_length = 50, $first_row = 0, &$row_count, &$total_hours)
+	public function getNotes($order = 'ASC', $list_length = 50, $first_row = 0, &$row_count = NULL, &$total_hours = NULL)
 	{
 		$clean_order = DB::escapeString($order);
 		//$clean_first_row = mysql_real_escape_string($first_row);


### PR DESCRIPTION
The function getNotes is called from three places in the codebase:
1. modules/case-act.php, where it is called with all 5 arguments specified
2. ops/transfer_case.php where it is called with only two arguments,
3. reports/quick_docket/report.php where it is called with only one argument.

This function as written provides default argument values for only 3 out of the 5 arguments. Prior to PHP version 7.1, passing too few arguments in situations like this would raise only a warning. Beginning with 7.1, it throws an error:
https://www.php.net/manual/en/migration71.incompatible.php

Adding default values for arguments 4 and 5 allows the function to be called with any number of arguments.